### PR TITLE
Build rc-0.5.0 docs from a single monorepo checkout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,10 +76,11 @@ jobs:
           path: 'stochtree_repo_py'
           submodules: 'recursive'
 
-      # C++ core source for Doxygen. Only some versions ship the C++ core +
-      # Doxyfile (e.g. the monorepo default branch); single-language packaged
-      # branches (r-rc-*, py-rc-*) do not, so this is gated on `build_cpp` and
-      # uses its own ref.
+      # C++ core source for Doxygen. Only monorepo branches ship the C++ core +
+      # Doxyfile; a version pinned to a single-language packaged branch (r-rc-*,
+      # py-rc-*) would not, so this stays gated on `build_cpp` and keeps its own
+      # ref. Every current version builds from a monorepo branch, so `cpp_ref`
+      # matches the R/Python refs.
       - name: Checkout stochtree C++ source (${{ matrix.cpp_ref || 'default' }})
         if: ${{ matrix.build_cpp }}
         uses: actions/checkout@v4
@@ -140,9 +141,11 @@ jobs:
           extra-packages: any::latex2exp, any::ggplot2, any::decor, any::pkgdown, any::reticulate, any::bayesplot, any::coda, any::doParallel, any::foreach, any::mvtnorm, any::rpart, any::rpart.plot, any::tgp, any::rprojroot
           needs: website
 
-      # The monorepo default branch assembles a CRAN-friendly package into
-      # stochtree_cran; pre-packaged branches (r-rc-*) already are that package,
-      # so they skip the bootstrap and point r_pkg_path at the checkout root.
+      # Monorepo branches assemble a CRAN-friendly package into stochtree_cran,
+      # which is also what carries _pkgdown.yml into the package pkgdown builds
+      # from (cran-bootstrap.R's second argument). A version pinned to a
+      # pre-packaged branch (r-rc-*) is already that package, so it would set
+      # r_bootstrap: false and point r_pkg_path at the checkout root instead.
       - name: Assemble CRAN-friendly R package
         if: ${{ matrix.r_bootstrap }}
         run: |

--- a/versions.json
+++ b/versions.json
@@ -13,12 +13,12 @@
   {
     "name": "rc-0.5.0",
     "docs_ref": "rc-0.5.0",
-    "cpp_ref": "main",
+    "cpp_ref": "rc-0.5.0",
     "build_cpp": true,
-    "r_ref": "r-rc-0.5.0",
-    "r_bootstrap": false,
-    "r_pkg_path": "stochtree_repo",
-    "py_ref": "py-rc-0.5.0",
+    "r_ref": "rc-0.5.0",
+    "r_bootstrap": true,
+    "r_pkg_path": "stochtree_repo/stochtree_cran",
+    "py_ref": "rc-0.5.0",
     "target": "v/rc-0.5.0"
   }
 ]


### PR DESCRIPTION
## What

Points every `rc-0.5.0` ref in `versions.json` at the monorepo `rc-0.5.0` branch and bootstraps the CRAN package the same way `latest` does.

```
cpp_ref      main            → rc-0.5.0
r_ref        r-rc-0.5.0      → rc-0.5.0
py_ref       py-rc-0.5.0     → rc-0.5.0
r_bootstrap  false           → true
r_pkg_path   stochtree_repo  → stochtree_repo/stochtree_cran
```

## Why

The RC version pinned its R and Python builds to the generated `r-rc-0.5.0` / `py-rc-0.5.0` deploy branches, which exist solely to ship installable packages. That caused three problems:

1. `r-rc-0.5.0` carries no `_pkgdown.yml`, so the RC R docs fell back to pkgdown's auto-generated reference index.
2. `cpp_ref` pointed at `main`, so the RC sub-site published **main's** Doxygen output.
3. The changelog was sourced from the packaged branch's `NEWS.md` rather than the monorepo copy, so RC release notes could lag.

Consolidating onto the monorepo branch fixes all three, and drops two moving parts from the matrix.

## No change to installed code

`py-rc-0.5.0` is deployed from `rc-0.5.0` HEAD exactly, and `r-rc-0.5.0` trailed it only by Python-only commits — so the R and Python packages built here are the same code that was being built before.

## Verification

Run locally against a fresh `rc-0.5.0` checkout:

- `Rscript cran-bootstrap.R 0 1 0` — clean, emits `stochtree_cran/` with `_pkgdown.yml` and `NEWS.md`
- `pkgdown::check_pkgdown()` — **No problems found**
- `pkgdown::build_site_github_pages(install = TRUE)` — **exit 0**, no errors in the log
- All 9 previously unindexed topics (`continueSampling`, `extractForest`, `extractRandomEffectSamples`, each plus `.bartmodel` / `.bcfmodel`) have reference pages and index entries
- Python package installs from the monorepo root, matching the consolidated `pip install .` step
- `Doxyfile` on `rc-0.5.0` carries the exact `OUTPUT_DIRECTORY` / `GENERATE_XML` / `GENERATE_HTML` lines the workflow's `sed` rewrites

Depends on StochasticTree/stochtree@b420d079, which fixes the `_pkgdown.yml` reference index and points the pkgdown `url` at the sub-site. Already pushed to `rc-0.5.0`.

## Note on testing

This workflow has no `push` trigger, so this PR builds **`latest` only** and does not exercise the RC path. After merge, run it via `workflow_dispatch` to test the consolidated RC build — the first real RC run will be a deploy.

Also updates two workflow comments that this change makes inaccurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)